### PR TITLE
Removed unwanted linebreaks in dataURI's

### DIFF
--- a/datauri.html
+++ b/datauri.html
@@ -14,16 +14,12 @@ object {width: 50%;}
 </style>
 <body>
 <h1>Clown Car Technique</h1>
-<object data="data:image/svg+xml,<svg viewBox='0 0 300 329' preserveAspectRatio='xMidYMid meet'
-xmlns='http://www.w3.org/2000/svg'><title>Clown Car Technique</title><style>svg{background-size:100% 100%;background-repeat:no-repeat;}@media screen and (max-width: 400px){svg{background-image:url(images/small.png);}}@media screen and (min-width: 401px) and (max-width:700px){svg{ background-image:url(images/medium.png);}}@media screen and (min-width: 701px) and (max-width:1000px){svg{background-image:url(images/big.png);}}@media screen and (min-width:1001px){svg{background-image:url(images/huge.png);}}</style></svg>"  type="image/svg+xml">
+<object data="data:image/svg+xml,<svg viewBox='0 0 300 329' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg'><title>Clown Car Technique</title><style>svg{background-size:100% 100%;background-repeat:no-repeat;}@media screen and (max-width: 400px){svg{background-image:url(images/small.png);}}@media screen and (min-width: 401px) and (max-width:700px){svg{ background-image:url(images/medium.png);}}@media screen and (min-width: 701px) and (max-width:1000px){svg{background-image:url(images/big.png);}}@media screen and (min-width:1001px){svg{background-image:url(images/huge.png);}}</style></svg>"  type="image/svg+xml">
 <!--[if lte IE 8]>
 <img src="images/medium.png" alt="Fall back for IE">
 <![endif]-->
 </object>
-<object data="data:image/svg+xml,<svg viewBox='0 0 300 329' preserveAspectRatio='xMidYMid meet'
-xmlns='http://www.w3.org/2000/svg'><title><style>svg{background-size:100% 100%;background-repeat:no-repeat;background-color: red;background-image:url(https://raw.github.com/estelle/clowncar/master/images/medium.png);}</style>Clown Car Technique</title><path fill='rgb(91, 183, 91)' d='M2.379,
-14.729L5.208,11.899L12.958,19.648L25.877,6.733L28.707,9.561L12.958,25.308Z'
-/></svg>" type="image/svg+xml"></object>
+<object data="data:image/svg+xml,<svg viewBox='0 0 300 329' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg'><title>Clown Car Technique</title><style>svg{background-size:100% 100%;background-repeat:no-repeat;background-color: red;background-image:url(https://raw.github.com/estelle/clowncar/master/images/medium.png);}</style><path fill='rgb(91, 183, 91)' d='M2.379,14.729L5.208,11.899L12.958,19.648L25.877,6.733L28.707,9.561L12.958,25.308Z'/></svg>" type="image/svg+xml"></object>
 <p>Resize window or edit CSS to change clowns</p>
 </body>
 </html>


### PR DESCRIPTION
I've stitched the dataURI's back together, made image urls consistent
and pulled the style tag out of the title tag on the bottom one.
